### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@ This Pom is auto-generated using 'gradlew mavenPom'</description>
     <dependency>
       <groupId>org.springframework.social</groupId>
       <artifactId>spring-social-alfresco</artifactId>
-      <version>0.2.7-RELEASE</version>
+      <version>0.2.8-RELEASE</version>
       <scope>compile</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Update pom.xml to point to the 0.2.8 release of Spring Social Alfresco. If you try to use the 0.2.7 release you'll get an error 500.
